### PR TITLE
[codex] fix version change autostart race

### DIFF
--- a/src-tauri/src/app_service.rs
+++ b/src-tauri/src/app_service.rs
@@ -413,12 +413,9 @@ pub async fn load_apps() -> Result<Vec<App>, Error> {
                 let app_name_clone = app.name.clone();
                 drop(auto_start_guard);
                 if let Some(app_handle) = get_app_handle() {
-                    let app_handle_clone = app_handle.clone();
-                    tokio::spawn(async move {
-                        if let Err(e) = start_app(app_handle_clone, app_name_clone.clone()).await {
-                            error!("Auto-start for app '{}' failed: {:?}", app_name_clone, e);
-                        }
-                    });
+                    if let Err(e) = start_app(app_handle.clone(), app_name_clone.clone()).await {
+                        error!("Auto-start for app '{}' failed: {:?}", app_name_clone, e);
+                    }
                 }
             } else {
                 info!(

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -165,6 +165,7 @@ function App() {
     // Tracks app names whose inline log is in 'completed' state — updated synchronously (not via useEffect)
     // so the apps event listener can always read the correct value before React re-renders.
     const completedAppsRef = useRef<Set<string>>(new Set());
+    const pendingVersionChangeAppsRef = useRef<Set<string>>(new Set());
     const [isInstallProcessRunning, setIsInstallProcessRunning] = useState<boolean>(false);
     const [isStartAppProcessRunning, setIsStartAppProcessRunning] = useState<boolean>(false);
     const [startingAppName, setStartingAppName] = useState<string | null>(null);
@@ -317,7 +318,6 @@ function App() {
                 }
                 return merged;
             });
-            updateStatus({loading: false});
         }));
 
         unlistenPromises.push(listen<App>("choose_app_profile", (event) => {
@@ -336,10 +336,13 @@ function App() {
             error?: boolean;
         }>("app-log", (event) => {
             const {app_name, finished, error} = event.payload;
+            const isPendingVersionChange = pendingVersionChangeAppsRef.current.has(app_name);
             setInlineUpdateLogs(prev => {
                 const entry = prev[app_name];
                 if (!entry || entry.completed) return prev;
+                if (!isPendingVersionChange) return prev;
                 if (finished) {
+                    pendingVersionChangeAppsRef.current.delete(app_name);
                     if (error) {
                         completedAppsRef.current.delete(app_name); // failed — not completed
                         return {...prev, [app_name]: {...entry, isConfirming: false, failed: true}};
@@ -347,18 +350,19 @@ function App() {
                         completedAppsRef.current.add(app_name); // mark completed immediately
                         return {...prev, [app_name]: {...entry, isConfirming: false, completed: true, failed: false}};
                     }
-                } else if (!entry.isConfirming) {
-                    return {...prev, [app_name]: {...entry, isConfirming: true, failed: false}};
                 }
                 return prev;
             });
-            if (finished && !error) {
+            if (finished && isPendingVersionChange) {
+                pendingVersionChangeAppsRef.current.delete(app_name);
+            }
+            if (finished && !error && isPendingVersionChange) {
                 setSelectedTargetVersions(prev => ({...prev, [app_name]: ''}));
             }
         }));
 
         (async () => {
-            await invokeTauriCommandWrapper<App[]>("load_apps", undefined, () => {},
+            await invokeTauriCommandWrapper<App[]>("load_apps", undefined, () => updateStatus({loading: false}),
                 (errorMessage, rawError) => {
                     console.error("Failed to initially load apps:", rawError);
                     updateStatus({error: `Failed to load apps: ${errorMessage}`, loading: false});
@@ -438,6 +442,7 @@ function App() {
     const handleConfirmVersionChange = async (params: { appName: string, version: string, actionType: string }) => {
         clearMessages();
         setAppActionLoading(prev => ({...prev, [params.appName]: true}));
+        pendingVersionChangeAppsRef.current.add(params.appName);
         // Mark as confirming so the inline log shows a spinner
         setInlineUpdateLogs(prev => ({
             ...prev,
@@ -455,7 +460,13 @@ function App() {
         await invokeTauriCommandWrapper<void>("update_to_version", {appName: params.appName, version: params.version, requirements: requirementsFile}, () => {},
             (errorMessage, rawError) => {
                 console.error(`Failed to invoke ${params.actionType.toLowerCase()}:`, rawError);
+                pendingVersionChangeAppsRef.current.delete(params.appName);
+                setAppActionLoading(prev => ({...prev, [params.appName]: false}));
                 setConsoleInitialMessage(prev => `${prev}\nERROR (client-side): Failed to dispatch operation: ${errorMessage}`);
+                setInlineUpdateLogs(prev => ({
+                    ...prev,
+                    [params.appName]: {...(prev[params.appName] ?? {version: params.version, actionType: params.actionType}), isConfirming: false, failed: true}
+                }));
             }
         );
     };
@@ -487,6 +498,7 @@ function App() {
         clearMessages();
         updateStatus({messageLoading: false});
         if (startingAppName) setAppActionLoading(prev => ({...prev, [startingAppName]: false}));
+        if (appNameForVersionChange) pendingVersionChangeAppsRef.current.delete(appNameForVersionChange);
         setStartingAppName(null);
         setVersionChangeConsoleData(null);
         setProfileChangeData(null);
@@ -668,7 +680,7 @@ function App() {
                         {apps.map((app) => {
                             const isEffectivelyInstalling = app.running && !app.installed;
                             const isThisAppLoading = appActionLoading[app.name] || false;
-                            const disableRowActions = currentPage !== 'list' || status.messageLoading || isThisAppLoading;
+                            const disableRowActions = currentPage !== 'list' || status.loading || status.messageLoading || isThisAppLoading;
                             return (
                                 <ListItem key={app.name} disablePadding sx={{mb: 2}}>
                                     <Card variant="outlined" sx={{width: '100%', bgcolor: (app.running) ? 'action.selected' : 'background.paper'}}>


### PR DESCRIPTION
﻿## Summary
- keep the version-change panel idle until the user actually confirms an update/downgrade
- ignore unrelated `app-log` events, such as auto-start logs, when deciding whether an inline version-change panel is confirming/completed
- keep first-load row actions disabled until `load_apps` finishes, and await auto-start detection before completing initial load

## Root cause
The inline update/downgrade panel listened to every `app-log` event for the app. When the user selected a target version during startup, PyAppify auto-start could emit startup logs for the same app before the user clicked confirm. The UI treated those unrelated logs as a version-change operation, switched the panel to `isConfirming`, hid the confirm/cancel buttons, and left the spinner running until the user changed the selected version again.

## Validation
- `pnpm build` with bundled Node.js: passed (`tsc && vite build`)
- `git diff --check`: passed

Rust tests were not run locally because `cargo` is not installed in this environment.
