### PR TITLE
修复启动器在用户未确认前自动执行动作，以及首次切换版本时确认区卡在加载状态的问题

### DIFF
--- a/src-tauri/src/app.rs
+++ b/src-tauri/src/app.rs
@@ -2,7 +2,7 @@
 use crate::utils::defender::is_defender_excluded;
 use crate::utils::path;
 use crate::utils::path::{get_app_base_path, get_app_working_dir_path};
-use anyhow::{anyhow, Context};
+use anyhow::Context;
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use std::fs;
@@ -241,8 +241,9 @@ pub(crate) async fn load_app_config_from_json(app_name: &str) -> anyhow::Result<
     let json_data = tokio::fs::read_to_string(&config_path)
         .await
         .with_context(|| format!("Failed to read app.json for {}", app_name))?;
+    let normalized_json_data = json_data.trim_start_matches('\u{feff}');
 
-    match serde_json::from_str::<App>(&json_data) {
+    match serde_json::from_str::<App>(normalized_json_data) {
         Ok(mut app) => {
             if app.name != app_name {
                 warn!("App name mismatch in app.json ('{}') and directory ('{}'). Correcting to directory name: '{}'.", app.name, app_name, app_name);
@@ -266,17 +267,29 @@ pub(crate) async fn load_app_config_from_json(app_name: &str) -> anyhow::Result<
             Ok(Some(app))
         }
         Err(e) => {
-            error!(
-                "Failed to deserialize app.json for {}: {}. Content sample: {}",
+            let bad_path = config_path.with_extension("json.bad");
+            warn!(
+                "Failed to deserialize app.json for {}: {}. Backing up invalid file to {} and rebuilding from embedded config.",
                 app_name,
                 e,
-                json_data.chars().take(200).collect::<String>()
+                bad_path.display()
             );
-            Err(anyhow!(
-                "Failed to deserialize app.json for {}: {}",
+            warn!(
+                "Invalid app.json content sample for {}: {}",
                 app_name,
-                e
-            ))
+                normalized_json_data.chars().take(200).collect::<String>()
+            );
+
+            if let Err(copy_err) = tokio::fs::copy(&config_path, &bad_path).await {
+                warn!(
+                    "Failed to back up invalid app.json for {} to {}: {}",
+                    app_name,
+                    bad_path.display(),
+                    copy_err
+                );
+            }
+
+            Ok(None)
         }
     }
 }

--- a/src-tauri/src/app_service.rs
+++ b/src-tauri/src/app_service.rs
@@ -1,9 +1,6 @@
 //src/app_service.rs
 use crate::app::App;
-use crate::config_manager::{
-    GLOBAL_CONFIG_STATE, UPDATE_METHOD_OPTION_AUTO, UPDATE_METHOD_OPTION_IGNORE,
-};
-use crate::emitter::get_app_handle;
+use crate::config_manager::{GLOBAL_CONFIG_STATE, UPDATE_METHOD_OPTION_AUTO};
 use crate::git::ensure_repository;
 use crate::runas;
 use crate::utils::error::Error;
@@ -340,6 +337,13 @@ pub async fn load_apps() -> Result<Vec<App>, Error> {
                 .find(|version| git::is_release_version(version))
                 .cloned();
             let current_version_missing = app.current_version_missing;
+            let has_pending_version_change_notice = app
+                .app_starting_version
+                .as_ref()
+                .zip(app.current_version.as_ref())
+                .is_some_and(|(starting_version, current_version)| {
+                    starting_version != current_version && !app.update_note.is_empty()
+                });
             let release_update_available =
                 latest_release_version
                     .as_ref()
@@ -355,77 +359,55 @@ pub async fn load_apps() -> Result<Vec<App>, Error> {
             let is_latest = !release_update_available;
 
             info!(
-                "First load, checking for auto-start conditions. update_method:{}, is_latest:{}, current_version_missing:{}",
-                update_method, is_latest, current_version_missing
+                "First load, checking for auto-start conditions. update_method:{}, is_latest:{}, current_version_missing:{}, has_pending_version_change_notice:{}",
+                update_method, is_latest, current_version_missing, has_pending_version_change_notice
             );
 
-            let mut needs_autostart = false;
             info!("locale is {}", get_locale());
             if app.installed && !app.available_versions.is_empty() {
                 if release_update_available {
-                    if current_version_missing {
-                        info!(
-                            "Current version is no longer available upstream. Forcing update to latest available release."
-                        );
-                    } else {
-                        info!("App is not the latest release version.");
-                    }
-                    let app_name_clone = app.name.clone();
                     let latest_version = latest_release_version
                         .expect("release_update_available requires latest release");
-                    if current_version_missing || update_method == UPDATE_METHOD_OPTION_AUTO {
+                    if current_version_missing {
                         info!(
-                            "{}",
-                            t!(
-                                "message.new_version_update",
-                                version = latest_version.clone()
-                            )
+                            "Current version is no longer available upstream. Waiting for explicit user action before updating to {}.",
+                            latest_version
                         );
-                        send_notification(
-                            app_name_clone.clone(),
-                            t!("message.new_version_update", version = latest_version),
-                        );
-                        update_to_version(&app_name_clone, &latest_version).await?;
-                        info!("Auto Update to version {} success.", &latest_version);
-                        send_notification(
-                            app_name_clone,
-                            t!("message.version_update_success", version = latest_version),
-                        );
-                        needs_autostart = true;
                     } else {
-                        send_notification(
-                            app_name_clone.clone(),
-                            t!("message.new_version", version = latest_version),
+                        info!(
+                            "App is not the latest release version. Waiting for explicit user action before updating to {}.",
+                            latest_version
                         );
-                        if update_method == UPDATE_METHOD_OPTION_IGNORE {
-                            info!("Auto-update is UPDATE_METHOD_OPTION_IGNORE set auto_start to true.");
-                            needs_autostart = true;
-                        }
                     }
+
+                    let app_name_clone = app.name.clone();
+                    let notification_key =
+                        if current_version_missing || update_method == UPDATE_METHOD_OPTION_AUTO {
+                            "message.new_version_update"
+                        } else {
+                            "message.new_version"
+                        };
+                    send_notification(
+                        app_name_clone,
+                        t!(notification_key, version = latest_version),
+                    );
+                } else if has_pending_version_change_notice {
+                    info!(
+                        "Pending version-change notice detected for app '{}'. Waiting for user action before any further operation.",
+                        app.name
+                    );
                 } else {
-                    needs_autostart = true;
-                    info!("App is the latest version and installed. set auto start to true");
+                    info!(
+                        "App '{}' is installed and up to date. Waiting for explicit user action instead of auto-starting.",
+                        app.name
+                    );
                 }
             }
 
-            if needs_autostart {
-                info!("Auto-starting app '{}'.", app.name);
-                let app_name_clone = app.name.clone();
-                drop(auto_start_guard);
-                if let Some(app_handle) = get_app_handle() {
-                    let app_handle_clone = app_handle.clone();
-                    tokio::spawn(async move {
-                        if let Err(e) = start_app(app_handle_clone, app_name_clone.clone()).await {
-                            error!("Auto-start for app '{}' failed: {:?}", app_name_clone, e);
-                        }
-                    });
-                }
-            } else {
-                info!(
-                    "Auto-start conditions not met for app '{}' (installed: {}, is_latest: {}).",
-                    app.name, app.installed, is_latest
-                );
-            }
+            info!(
+                "First-load automation is disabled for app '{}' (installed: {}, is_latest: {}).",
+                app.name, app.installed, is_latest
+            );
         }
     }
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -174,6 +174,7 @@ function App() {
         version: string;
         actionType: string;
     } | null>(null);
+    const activeVersionChangeAppRef = useRef<string | null>(null);
     const [isVersionChangeProcessRunning, setIsVersionChangeProcessRunning] = useState<boolean>(false);
     const [isRunningAppConsoleOpen, setIsRunningAppConsoleOpen] = useState<boolean>(false);
     const [themeMode, setThemeMode] = useState<ThemeModeSetting>(() => {
@@ -336,6 +337,9 @@ function App() {
             error?: boolean;
         }>("app-log", (event) => {
             const {app_name, finished, error} = event.payload;
+            if (activeVersionChangeAppRef.current !== app_name) {
+                return;
+            }
             setInlineUpdateLogs(prev => {
                 const entry = prev[app_name];
                 if (!entry || entry.completed) return prev;
@@ -347,8 +351,6 @@ function App() {
                         completedAppsRef.current.add(app_name); // mark completed immediately
                         return {...prev, [app_name]: {...entry, isConfirming: false, completed: true, failed: false}};
                     }
-                } else if (!entry.isConfirming) {
-                    return {...prev, [app_name]: {...entry, isConfirming: true, failed: false}};
                 }
                 return prev;
             });
@@ -438,6 +440,7 @@ function App() {
     const handleConfirmVersionChange = async (params: { appName: string, version: string, actionType: string }) => {
         clearMessages();
         setAppActionLoading(prev => ({...prev, [params.appName]: true}));
+        activeVersionChangeAppRef.current = params.appName;
         // Mark as confirming so the inline log shows a spinner
         setInlineUpdateLogs(prev => ({
             ...prev,
@@ -490,6 +493,7 @@ function App() {
         setStartingAppName(null);
         setVersionChangeConsoleData(null);
         setProfileChangeData(null);
+        activeVersionChangeAppRef.current = null;
 
         // After a version change: clear version selector and mark log as completed (shows success state)
         if (wasVersionChange && appNameForVersionChange) {


### PR DESCRIPTION
## 问题描述

这个 PR 修复了启动器中的两个相关问题：

1. 启动器在用户尚未明确操作前，会自动执行启动或版本相关动作
2. 用户首次切换目标版本时，升级/降级确认区会长时间停留在加载状态，通常需要再次切换版本才会正常显示确认按钮

## 预期行为

启动器在用户未明确确认前，不应自动启动应用，也不应自动推进版本切换相关动作。
当用户第一次选择目标版本时，应立即正常显示升级/降级确认区。

## 原因分析

### 1. 未经用户确认的自动动作
启动器在首次加载应用状态时，会根据安装状态、版本状态和更新策略直接推导自动动作。
这会导致用户还没确认时，启动器就已经启动应用或者推进版本相关流程，交互上不够友好。

### 2. 首次切换版本时确认区卡在加载
前端会监听通用的 `app-log` 事件来更新内联版本切换面板状态。
但在用户尚未真正确认版本切换前，某些无关日志事件也会把面板错误地标记为“确认中”，导致确认按钮被提前隐藏，看起来像一直在加载。

## 修复内容

- 禁止首次加载时隐式自动启动应用
- 禁止首次加载时在用户未确认前自动推进版本相关动作
- 在存在待确认的版本切换说明时，显式等待用户操作
- 前端只在真正进入版本切换流程后，才允许相关日志驱动面板进入“确认中”状态
- 增加对异常 `app.json` 的容错处理，避免状态文件异常时直接导致启动器加载失败

## 修复效果

- 启动器在用户未操作前，不会自动启动应用
- 启动器在用户未确认前，不会自动推进版本切换动作
- 首次选择升级/降级目标版本时，确认区会立即正常显示
- 不再需要通过“再次切换版本”来触发确认按钮显示
- 异常状态文件不会直接导致整个启动器页面加载失败