### PR TITLE
修复运行时重新创建被用户删除的桌面快捷方式

### DIFF
--- a/src-tauri/src/utils/window.rs
+++ b/src-tauri/src/utils/window.rs
@@ -117,6 +117,19 @@ fn build_app_shortcut(
     Ok(link)
 }
 
+fn existing_desktop_shortcuts(
+    desktop_dir: &Path,
+    app_filename: &str,
+    launcher_filename: &str,
+) -> (Option<PathBuf>, Option<PathBuf>) {
+    let app_shortcut = desktop_dir.join(app_filename);
+    let launcher_shortcut = desktop_dir.join(launcher_filename);
+    (
+        app_shortcut.exists().then_some(app_shortcut),
+        launcher_shortcut.exists().then_some(launcher_shortcut),
+    )
+}
+
 #[cfg(windows)]
 fn write_app_shortcut(
     shortcut_path: &Path,
@@ -230,8 +243,13 @@ pub async fn update_app_shortcuts(
             return Err(anyhow::Error::from(error).into());
         }
     };
-    let desktop_shortcut = desktop_dir.join(shortcut_filename);
-    if desktop_shortcut.exists() {
+    let launcher_filename = format!("{}.lnk", launcher_name);
+    let (desktop_shortcut, desktop_launcher_shortcut) = existing_desktop_shortcuts(
+        &desktop_dir,
+        &shortcut_filename,
+        &launcher_filename,
+    );
+    if let Some(desktop_shortcut) = desktop_shortcut {
         write_app_shortcut(
             &desktop_shortcut,
             &target_path,
@@ -241,7 +259,13 @@ pub async fn update_app_shortcuts(
             icon_path.as_deref(),
             run_as_admin,
         )?;
-        let desktop_launcher_shortcut = desktop_dir.join(format!("{}.lnk", launcher_name));
+    } else {
+        info!(
+            "No existing Desktop shortcut at '{}'; nothing to update.",
+            desktop_dir.join(&shortcut_filename).display()
+        );
+    }
+    if let Some(desktop_launcher_shortcut) = desktop_launcher_shortcut {
         write_app_shortcut(
             &desktop_launcher_shortcut,
             &launcher_target,
@@ -253,8 +277,8 @@ pub async fn update_app_shortcuts(
         )?;
     } else {
         info!(
-            "No existing Desktop shortcut at '{}'; nothing to update.",
-            desktop_shortcut.display()
+            "No existing Desktop launcher shortcut at '{}'; nothing to update.",
+            desktop_dir.join(&launcher_filename).display()
         );
     }
     info!(
@@ -279,8 +303,10 @@ pub async fn update_app_shortcuts(
 
 #[cfg(test)]
 mod tests {
-    use super::build_app_shortcut;
+    use super::{build_app_shortcut, existing_desktop_shortcuts};
     use shortcuts_rs::LinkFlags;
+    use std::fs;
+    use std::time::{SystemTime, UNIX_EPOCH};
 
     #[test]
     fn app_shortcut_starts_python_directly_and_uses_its_icon() {
@@ -310,5 +336,39 @@ mod tests {
         assert!(flags.contains(LinkFlags::HAS_ICON_LOCATION));
         assert!(flags.contains(LinkFlags::HAS_WORKING_DIR));
         assert!(flags.contains(LinkFlags::RUN_AS_USER));
+    }
+
+    #[test]
+    fn desktop_shortcuts_are_updated_only_when_each_one_exists() {
+        let unique = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        let desktop_dir = std::env::temp_dir().join(format!(
+            "pyappify-desktop-shortcuts-{}-{unique}",
+            std::process::id()
+        ));
+        fs::create_dir_all(&desktop_dir).unwrap();
+
+        let (app, launcher) = existing_desktop_shortcuts(&desktop_dir, "app.lnk", "launcher.lnk");
+        assert!(app.is_none());
+        assert!(launcher.is_none());
+
+        let app_path = desktop_dir.join("app.lnk");
+        let launcher_path = desktop_dir.join("launcher.lnk");
+        fs::write(&app_path, []).unwrap();
+        let (app, launcher) = existing_desktop_shortcuts(&desktop_dir, "app.lnk", "launcher.lnk");
+        assert_eq!(app.as_deref(), Some(app_path.as_path()));
+        assert!(launcher.is_none());
+
+        fs::write(&launcher_path, []).unwrap();
+        let (app, launcher) = existing_desktop_shortcuts(&desktop_dir, "app.lnk", "launcher.lnk");
+        assert_eq!(app.as_deref(), Some(app_path.as_path()));
+        assert_eq!(
+            launcher.as_deref(),
+            Some(launcher_path.as_path())
+        );
+
+        fs::remove_dir_all(desktop_dir).unwrap();
     }
 }


### PR DESCRIPTION
## 问题

应用成功启动后，PyAppify 会调用 `update_app_shortcuts`。当前实现用桌面应用快捷方式是否存在作为总开关：

- 应用快捷方式存在时，更新桌面应用快捷方式；
- 同时无条件创建或更新桌面启动器快捷方式。

这会导致用户删除桌面启动器快捷方式后，只要桌面应用快捷方式仍存在，下一次启动或更新就把启动器快捷方式恢复。

## 修复

让两个桌面快捷方式分别遵循“存在才更新”：

- 桌面应用快捷方式存在时，只更新桌面应用快捷方式；
- 桌面启动器快捷方式存在时，只更新桌面启动器快捷方式；
- 两者都不存在时，不创建任何桌面快捷方式。

开始菜单快捷方式行为保持不变。用户删除桌面快捷方式后，后续启动不会再恢复；用户手动创建的快捷方式仍可被后续启动维护。

## 验证

新增回归测试覆盖：

1. 两个快捷方式都不存在；
2. 只有应用快捷方式存在；
3. 两个快捷方式都存在。

本地环境未安装 Rust 工具链，未能执行 Cargo 测试；已通过 `git diff --check`，请由 CI 完成编译和测试验证。
